### PR TITLE
[TASK] patch exception thrown with missing language parameter

### DIFF
--- a/Classes/Encoder/UrlEncoder.php
+++ b/Classes/Encoder/UrlEncoder.php
@@ -1376,6 +1376,7 @@ class UrlEncoder extends EncodeDecoderBase {
 	 */
 	protected function validateLanguageParameter($sysLanguageUid) {
 		static $sysLanguages = null;
+        if ($sysLanguageUid == '') $sysLanguageUid = 0;
 
 		if (!MathUtility::canBeInterpretedAsInteger($sysLanguageUid)) {
 			$isValidLanguageUid = false;


### PR DESCRIPTION
If the language parameter is not set the function canBeItnerpretedAsInteger
returns false because of empty string, but if the default language is used
no langauge parameter is added to the url.

Patch: If L parameter contains an empty string set it to 0.